### PR TITLE
Fix for Python 3.9

### DIFF
--- a/openapi_pydantic/compat.py
+++ b/openapi_pydantic/compat.py
@@ -1,6 +1,6 @@
 """Compatibility layer to make this package usable with Pydantic 1 or 2"""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
     def ConfigDict(
         extra: Literal["allow", "ignore", "forbid"] = "allow",
-        json_schema_extra: dict[str, Any] | None = None,
+        json_schema_extra: Optional[dict[str, Any]] = None,
         populate_by_name: bool = True,
     ) -> PydanticConfigDict:
         """Stub for pydantic.ConfigDict in Pydantic 2"""
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
         *,
         by_alias: bool = True,
         ref_template: str = "#/$defs/{model}",
-        schema_generator: type | None = None,
+        schema_generator: Optional[type] = None,
     ) -> tuple[dict, dict[str, Any]]:
         """Stub for pydantic.json_schema.models_json_schema in Pydantic 2"""
         ...

--- a/openapi_pydantic/v3/v3_0_3/schema.py
+++ b/openapi_pydantic/v3/v3_0_3/schema.py
@@ -602,9 +602,9 @@ if TYPE_CHECKING:
     def schema_validate(
         obj: Any,
         *,
-        strict: bool | None = None,
-        from_attributes: bool | None = None,
-        context: dict[str, Any] | None = None
+        strict: Optional[bool] = None,
+        from_attributes: Optional[bool] = None,
+        context: Optional[dict[str, Any]] = None
     ) -> Schema:
         ...
 

--- a/openapi_pydantic/v3/v3_0_3/util.py
+++ b/openapi_pydantic/v3/v3_0_3/util.py
@@ -1,5 +1,16 @@
 import logging
-from typing import TYPE_CHECKING, Any, Generic, List, Optional, Set, Type, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generic,
+    List,
+    Optional,
+    Set,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from pydantic import BaseModel
 
@@ -143,7 +154,7 @@ def construct_open_api_with_schema_class(
 
 def _validate_schemas(
     schema_definitions: dict[str, Any]
-) -> dict[str, Reference | Schema]:
+) -> dict[str, Union[Reference, Schema]]:
     """Convert JSON Schema definitions to parsed OpenAPI objects"""
     # Note: if an error occurs in schema_validate(), it may indicate that
     # the generated JSON schemas are not compatible with the version

--- a/openapi_pydantic/v3/v3_1_0/schema.py
+++ b/openapi_pydantic/v3/v3_1_0/schema.py
@@ -959,9 +959,9 @@ if TYPE_CHECKING:
     def schema_validate(
         obj: Any,
         *,
-        strict: bool | None = None,
-        from_attributes: bool | None = None,
-        context: dict[str, Any] | None = None
+        strict: Optional[bool] = None,
+        from_attributes: Optional[bool] = None,
+        context: Optional[dict[str, Any]] = None
     ) -> Schema:
         ...
 

--- a/tests/util/test_optional_and_computed.py
+++ b/tests/util/test_optional_and_computed.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 
 from openapi_pydantic import (
@@ -69,7 +71,7 @@ def construct_sample_api() -> OpenAPI:
 
     class SampleModel(BaseModel):
         req: bool
-        opt: bool | None = None
+        opt: Optional[bool] = None
 
         @computed_field  # type: ignore
         @property

--- a/tests/v3_0_3/test_optional_and_computed.py
+++ b/tests/v3_0_3/test_optional_and_computed.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import pytest
 
 from openapi_pydantic.compat import PYDANTIC_V2, JsonSchemaMode
@@ -72,7 +74,7 @@ def construct_sample_api() -> OpenAPI:
 
     class SampleModel(BaseModel):
         req: bool
-        opt: bool | None = None
+        opt: Optional[bool] = None
 
         @computed_field  # type: ignore
         @property

--- a/tox.ini
+++ b/tox.ini
@@ -1,42 +1,27 @@
 [tox]
 min_version = 4.0
-env_list = format, test_pydantic1, type_pydantic1, test_pydantic2, type_pydantic2, lint, py{3.9,3.10,3.11}
+env_list = format, lint, py{39,310,311}-pydantic{1,2}
 
 [gh-actions]
 python =
     3.9: py39
     3.10: py310
-    3.11: py311, test_pydantic1, type_pydantic1, test_pydantic2, type_pydantic2, format, lint
+    3.11: format, lint, py311
 
-[testenv:test_pydantic1]
+[testenv]
 labels = core
 allowlist_externals = poetry
+# The "pydanticX:" prefixes are Tox factor-conditional settings.
+# https://tox.wiki/en/3.4.0/config.html?highlight=conditional#factors-and-factor-conditional-settings
+# Note that "poetry add" changes pyproject.toml, but at least we
+# change it back when the tests finish.
 commands_pre =
-  poetry install --only main --only test --no-root --all-extras
-  poetry add pydantic^1
-commands = poetry run pytest -vv tests
-
-[testenv:type_pydantic1]
-allowlist_externals = poetry
-commands_pre =
+  pydantic1: poetry add pydantic<2
+  pydantic2: poetry add pydantic>=1.8
   poetry install --no-root --all-extras
-  poetry add pydantic^1
-commands = poetry run mypy openapi_pydantic tests
-
-[testenv:test_pydantic2]
-labels = core
-allowlist_externals = poetry
-commands_pre =
-  poetry install --only main --only test --no-root --all-extras
-  poetry add 'pydantic>=1.8'
-commands = poetry run pytest -vv tests
-
-[testenv:type_pydantic2]
-allowlist_externals = poetry
-commands_pre =
-  poetry install --no-root --all-extras
-  poetry add 'pydantic>=1.8'
-commands = poetry run mypy openapi_pydantic tests
+commands =
+  poetry run pytest -vv tests
+  poetry run mypy openapi_pydantic tests
 
 [testenv:format]
 allowlist_externals = poetry

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 min_version = 4.0
-env_list = format, lint, py{39,310,311}-pydantic{1,2}
+env_list = format, lint, py{39,310,311}-pydantic{1,2}-test, py{39,310,311}-pydantic{1,2}-type
 
 [gh-actions]
 python =
@@ -11,17 +11,17 @@ python =
 [testenv]
 labels = core
 allowlist_externals = poetry
-# The "pydanticX:" prefixes are Tox factor-conditional settings.
+# The "pydanticX:", "test:", and "type:" prefixes are Tox factor-conditional settings.
 # https://tox.wiki/en/3.4.0/config.html?highlight=conditional#factors-and-factor-conditional-settings
 # Note that "poetry add" changes pyproject.toml, but at least we
 # change it back when the tests finish.
 commands_pre =
-  pydantic1: poetry add pydantic<2
-  pydantic2: poetry add pydantic>=1.8
+  pydantic1: poetry add --lock pydantic<2
+  pydantic2: poetry add --lock pydantic>=1.8
   poetry install --no-root --all-extras
 commands =
-  poetry run pytest -vv tests
-  poetry run mypy openapi_pydantic tests
+  test: poetry run pytest -vv tests
+  type: poetry run mypy openapi_pydantic tests
 
 [testenv:format]
 allowlist_externals = poetry

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 min_version = 4.0
-env_list = format, lint, py{39,310,311}-pydantic{1,2}-test, py{39,310,311}-pydantic{1,2}-type
+env_list = format, lint, py{39,310,311}-pydantic{1,2}-{test,type}
 
 [gh-actions]
 python =


### PR DESCRIPTION
While testing, I discovered Python 3.9 support is broken in 0.3.0 due to the use of `|` union operators. This PR replaces `|` with `Union[...]` and `Optional[...]` and cleans up `tox.ini` so that the tests are run for every supported version of Python.