### PR TITLE
fix: Make type hints compatible with Python 3.8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         uses: snok/install-poetry@v1
         with:
           virtualenvs-create: false
-          version: 1.5.0
+          version: 1.5.1
       - name: Build package distribution
         run: poetry build
       - name: Upload package artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -26,7 +26,7 @@ jobs:
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
-        version: 1.5.0
+        version: 1.5.1
         virtualenvs-create: true
         virtualenvs-in-project: true
     - name: Run tox test suite

--- a/openapi_pydantic/compat.py
+++ b/openapi_pydantic/compat.py
@@ -1,6 +1,6 @@
 """Compatibility layer to make this package usable with Pydantic 1 or 2"""
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from pydantic.version import VERSION as PYDANTIC_VERSION
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
     def ConfigDict(
         extra: Literal["allow", "ignore", "forbid"] = "allow",
-        json_schema_extra: Optional[dict[str, Any]] = None,
+        json_schema_extra: Optional[Dict[str, Any]] = None,
         populate_by_name: bool = True,
     ) -> PydanticConfigDict:
         """Stub for pydantic.ConfigDict in Pydantic 2"""
@@ -49,21 +49,21 @@ if TYPE_CHECKING:
     JsonSchemaMode = Literal["validation", "serialization"]
 
     def models_json_schema(
-        models: list[tuple[Type[BaseModel], JsonSchemaMode]],
+        models: List[Tuple[Type[BaseModel], JsonSchemaMode]],
         *,
         by_alias: bool = True,
         ref_template: str = "#/$defs/{model}",
         schema_generator: Optional[type] = None,
-    ) -> tuple[dict, dict[str, Any]]:
+    ) -> Tuple[Dict, Dict[str, Any]]:
         """Stub for pydantic.json_schema.models_json_schema in Pydantic 2"""
         ...
 
     def v1_schema(
-        models: list[Type[BaseModel]],
+        models: List[Type[BaseModel]],
         *,
         by_alias: bool = True,
         ref_prefix: str = "#/$defs",
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         """Stub for pydantic.schema.schema in Pydantic 1"""
         ...
 

--- a/openapi_pydantic/util.py
+++ b/openapi_pydantic/util.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Generic, List, Optional, Set, Type, TypeVar, cast
+from typing import Any, Dict, Generic, List, Optional, Set, Type, TypeVar, cast
 
 from pydantic import BaseModel
 
@@ -110,7 +110,7 @@ def construct_open_api_with_schema_class(
     return new_open_api
 
 
-def _validate_schemas(schema_definitions: dict[str, Any]) -> dict[str, Schema]:
+def _validate_schemas(schema_definitions: Dict[str, Any]) -> Dict[str, Schema]:
     """Convert JSON Schema definitions to parsed OpenAPI objects"""
     # Note: if an error occurs in schema_validate(), it may indicate that
     # the generated JSON schemas are not compatible with the version

--- a/openapi_pydantic/v3/v3_0_3/schema.py
+++ b/openapi_pydantic/v3/v3_0_3/schema.py
@@ -604,7 +604,7 @@ if TYPE_CHECKING:
         *,
         strict: Optional[bool] = None,
         from_attributes: Optional[bool] = None,
-        context: Optional[dict[str, Any]] = None
+        context: Optional[Dict[str, Any]] = None
     ) -> Schema:
         ...
 

--- a/openapi_pydantic/v3/v3_0_3/util.py
+++ b/openapi_pydantic/v3/v3_0_3/util.py
@@ -2,6 +2,7 @@ import logging
 from typing import (
     TYPE_CHECKING,
     Any,
+    Dict,
     Generic,
     List,
     Optional,
@@ -153,8 +154,8 @@ def construct_open_api_with_schema_class(
 
 
 def _validate_schemas(
-    schema_definitions: dict[str, Any]
-) -> dict[str, Union[Reference, Schema]]:
+    schema_definitions: Dict[str, Any]
+) -> Dict[str, Union[Reference, Schema]]:
     """Convert JSON Schema definitions to parsed OpenAPI objects"""
     # Note: if an error occurs in schema_validate(), it may indicate that
     # the generated JSON schemas are not compatible with the version

--- a/openapi_pydantic/v3/v3_1_0/schema.py
+++ b/openapi_pydantic/v3/v3_1_0/schema.py
@@ -961,7 +961,7 @@ if TYPE_CHECKING:
         *,
         strict: Optional[bool] = None,
         from_attributes: Optional[bool] = None,
-        context: Optional[dict[str, Any]] = None
+        context: Optional[Dict[str, Any]] = None
     ) -> Schema:
         ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openapi-pydantic"
-version = "0.3.1"
+version = "0.3.2"
 description = "Pydantic OpenAPI schema implementation"
 authors = ["Mike Oakley <mike-oakley@users.noreply.github.com>"]
 readme = "README.md"

--- a/tests/util/test_pydantic_field.py
+++ b/tests/util/test_pydantic_field.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any, Dict, Union
 
 from pydantic import BaseModel, Field
 from typing_extensions import Literal
@@ -59,8 +59,8 @@ def construct_base_open_api() -> OpenAPI:
 def test_pydantic_discriminator_schema_generation() -> None:
     """https://github.com/kuimono/openapi-schema-pydantic/issues/8"""
 
-    a_kind: dict[str, Any]
-    b_kind: dict[str, Any]
+    a_kind: Dict[str, Any]
+    b_kind: Dict[str, Any]
 
     if PYDANTIC_V2:
         _key_map, json_schema = models_json_schema([(RequestModel, "validation")])

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 min_version = 4.0
-env_list = format, lint, py{39,310,311}-pydantic{1,2}-{test,type}
+env_list = format, lint, py{38,39,310,311}-pydantic{1,2}-{test,type}
 
 [gh-actions]
 python =
+    3.8: py38
     3.9: py39
     3.10: py310
     3.11: format, lint, py311


### PR DESCRIPTION
- Adds Python 3.8 to test matrix
- Fixes type hints to be Python 3.8 compatible