### PR TITLE
python <= 3.7 compatibility, support for collision pydantic schema names

### DIFF
--- a/openapi_pydantic/compat.py
+++ b/openapi_pydantic/compat.py
@@ -15,6 +15,8 @@ __all__ = [
     "v1_schema",
     "DEFS_KEY",
     "min_length_arg",
+    "get_flat_models_from_models",
+    "get_model_name_map"
 ]
 
 PYDANTIC_MAJOR_VERSION = int(PYDANTIC_VERSION.split(".", 1)[0])
@@ -100,12 +102,14 @@ elif PYDANTIC_V2:
     # Create V1 stubs. These should not be used when PYDANTIC_V2 is true.
     Extra = None
     v1_schema = None
+    get_flat_models_from_models = None
+    get_model_name_map = None
 
 
 else:
 
     from pydantic import Extra
-    from pydantic.schema import schema as v1_schema
+    from pydantic.schema import schema as v1_schema, get_flat_models_from_models, get_model_name_map
 
     # Pydantic 1 renders JSON schemas using the keyword "definitions"
     DEFS_KEY = "definitions"

--- a/openapi_pydantic/compat.py
+++ b/openapi_pydantic/compat.py
@@ -1,5 +1,6 @@
 """Compatibility layer to make this package usable with Pydantic 1 or 2"""
 
+import sys
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 from pydantic.version import VERSION as PYDANTIC_VERSION
@@ -19,11 +20,17 @@ __all__ = [
 PYDANTIC_MAJOR_VERSION = int(PYDANTIC_VERSION.split(".", 1)[0])
 PYDANTIC_V2 = PYDANTIC_MAJOR_VERSION >= 2
 
+if sys.version_info.minor >= 8:
+    from typing import TypedDict, Literal
+else:
+    # Provide python <= 3.7 compatibility
+    from typing_extensions import TypedDict, Literal
+
 if TYPE_CHECKING:
     # Provide stubs for either version of Pydantic
 
     from enum import Enum
-    from typing import Any, Literal, Type, TypedDict
+    from typing import Any, Type
 
     from pydantic import BaseModel
     from pydantic import ConfigDict as PydanticConfigDict
@@ -77,7 +84,6 @@ if TYPE_CHECKING:
         ...
 
 elif PYDANTIC_V2:
-    from typing import TypedDict
 
     from pydantic import ConfigDict, RootModel
     from pydantic.json_schema import JsonSchemaMode, models_json_schema
@@ -97,7 +103,6 @@ elif PYDANTIC_V2:
 
 
 else:
-    from typing import TypedDict
 
     from pydantic import Extra
     from pydantic.schema import schema as v1_schema

--- a/openapi_pydantic/v3/v3_0_3/open_api.py
+++ b/openapi_pydantic/v3/v3_0_3/open_api.py
@@ -1,4 +1,11 @@
-from typing import List, Literal, Optional
+import sys
+if sys.version_info.minor >= 8:
+    # Provide python <= 3.7 compatibility
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+from typing import List, Optional
 
 from pydantic import BaseModel
 

--- a/openapi_pydantic/v3/v3_1_0/open_api.py
+++ b/openapi_pydantic/v3/v3_1_0/open_api.py
@@ -1,4 +1,11 @@
-from typing import Dict, List, Literal, Optional, Union
+import sys
+if sys.version_info.minor >= 8:
+    # Provide python <= 3.7 compatibility
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 include = ["openapi_pydantic/py.typed"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7"
 pydantic = ">=1.8"
 
 [tool.poetry.group.test.dependencies]

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,4 +1,10 @@
-from typing import Literal
+import sys
+if sys.version_info.minor >= 8:
+    from typing import Literal
+else:
+    # Provide python <= 3.7 compatibility
+    from typing_extensions import Literal
+
 
 import pytest
 

--- a/tests/v3_0_3/test_util.py
+++ b/tests/v3_0_3/test_util.py
@@ -1,5 +1,13 @@
 import logging
-from typing import Callable, Literal
+import sys
+
+if sys.version_info.minor >= 8:
+    # Provide python <= 3.7 compatibility
+    from typing import Literal
+else:
+    from typing_extensions import Literal
+
+from typing import Callable
 
 from pydantic import BaseModel, Field
 


### PR DESCRIPTION
The only difference comparing to upstream library (openapi-schema-pydantic), that increases requirements from Python >=3.6.1 to Python >=3.8 i see is imports TypedDict and Literal from typing

Fixed it with sys.version_info checking before imports and importing it from typing_extensions
All tests ran successfully!