### PR TITLE
fix: replace invalid characters in $ref field with underscore.

### DIFF
--- a/openapi_pydantic/util.py
+++ b/openapi_pydantic/util.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import Any, Dict, Generic, List, Optional, Set, Type, TypeVar, cast
 
 from pydantic import BaseModel
@@ -170,6 +171,9 @@ def _handle_pydantic_schema(open_api: OpenAPI) -> List[Type[BaseModel]]:
 
 
 def _construct_ref_obj(pydantic_schema: PydanticSchema[PydanticType]) -> Reference:
-    ref_obj = Reference(**{"$ref": ref_prefix + pydantic_schema.schema_class.__name__})
+    ref_name = re.sub(
+        r"[^a-zA-Z0-9.\-_]", "_", pydantic_schema.schema_class.__name__
+    ).replace(".", "__")
+    ref_obj = Reference(**{"$ref": ref_prefix + ref_name})
     logger.debug(f"ref_obj={ref_obj}")
     return ref_obj

--- a/openapi_pydantic/util.py
+++ b/openapi_pydantic/util.py
@@ -171,6 +171,15 @@ def _handle_pydantic_schema(open_api: OpenAPI) -> List[Type[BaseModel]]:
 
 
 def _construct_ref_obj(pydantic_schema: PydanticSchema[PydanticType]) -> Reference:
+    """
+    Construct a reference object from the Pydantic schema name
+
+    characters in the schema name that are invalid/problematic
+    for JSONschema $ref names will get replaced with underscores.
+    Especially needed for Pydantic generic Models with brackets "[]"
+
+    see: https://github.com/pydantic/pydantic/blob/aee6057378ccfec02126bf9c984a9b6d6b411777/pydantic/json_schema.py#L2031
+    """
     ref_name = re.sub(
         r"[^a-zA-Z0-9.\-_]", "_", pydantic_schema.schema_class.__name__
     ).replace(".", "__")

--- a/openapi_pydantic/v3/v3_0/util.py
+++ b/openapi_pydantic/v3/v3_0/util.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -242,6 +243,9 @@ def _handle_pydantic_schema(open_api: OpenAPI) -> List[Type[BaseModel]]:
 
 
 def _construct_ref_obj(pydantic_schema: PydanticSchema[PydanticType]) -> Reference:
-    ref_obj = Reference(**{"$ref": ref_prefix + pydantic_schema.schema_class.__name__})
+    ref_name = re.sub(
+        r"[^a-zA-Z0-9.\-_]", "_", pydantic_schema.schema_class.__name__
+    ).replace(".", "__")
+    ref_obj = Reference(**{"$ref": ref_prefix + ref_name})
     logger.debug(f"ref_obj={ref_obj}")
     return ref_obj

--- a/openapi_pydantic/v3/v3_0/util.py
+++ b/openapi_pydantic/v3/v3_0/util.py
@@ -243,6 +243,15 @@ def _handle_pydantic_schema(open_api: OpenAPI) -> List[Type[BaseModel]]:
 
 
 def _construct_ref_obj(pydantic_schema: PydanticSchema[PydanticType]) -> Reference:
+    """
+    Construct a reference object from the Pydantic schema name
+
+    characters in the schema name that are invalid/problematic
+    for JSONschema $ref names will get replaced with underscores.
+    Especially needed for Pydantic generic Models with brackets "[]"
+
+    see: https://github.com/pydantic/pydantic/blob/aee6057378ccfec02126bf9c984a9b6d6b411777/pydantic/json_schema.py#L2031
+    """
     ref_name = re.sub(
         r"[^a-zA-Z0-9.\-_]", "_", pydantic_schema.schema_class.__name__
     ).replace(".", "__")

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -1,6 +1,7 @@
 import logging
-from typing import Callable
+from typing import Callable, Generic, TypeVar
 
+import pytest
 from pydantic import BaseModel, Field
 
 from openapi_pydantic import (
@@ -66,6 +67,43 @@ def test_construct_open_api_with_schema_class_3() -> None:
     assert schema_without_alias.properties is not None
     assert "resp_foo" in schema_without_alias.properties
     assert "resp_bar" in schema_without_alias.properties
+
+
+@pytest.mark.skipif(PYDANTIC_V2, reason="generic type for Pydantic V1")
+def test_construct_open_api_with_schema_class_4_generic_response_v1() -> None:
+    DataT = TypeVar("DataT")
+    from pydantic.v1.generics import GenericModel
+
+    class GenericResponse(GenericModel, Generic[DataT]):
+        msg: str = Field(description="message of the generic response")
+        data: DataT = Field(description="data value of the generic response")
+
+    open_api_4 = construct_base_open_api_4_generic_response(
+        GenericResponse[PongResponse]
+    )
+
+    result = construct_open_api_with_schema_class(open_api_4)
+    assert result.components is not None
+    assert result.components.schemas is not None
+    assert "GenericResponse_PongResponse_" in result.components.schemas
+
+
+@pytest.mark.skipif(not PYDANTIC_V2, reason="generic type for Pydantic V2")
+def test_construct_open_api_with_schema_class_4_generic_response_v2() -> None:
+    DataT = TypeVar("DataT")
+
+    class GenericResponse(BaseModel, Generic[DataT]):
+        msg: str = Field(description="message of the generic response")
+        data: DataT = Field(description="data value of the generic response")
+
+    open_api_4 = construct_base_open_api_4_generic_response(
+        GenericResponse[PongResponse]
+    )
+
+    result = construct_open_api_with_schema_class(open_api_4)
+    assert result.components is not None
+    assert result.components.schemas is not None
+    assert "GenericResponse_PongResponse_" in result.components.schemas
 
 
 def construct_base_open_api_1() -> OpenAPI:
@@ -165,6 +203,42 @@ def construct_base_open_api_3() -> OpenAPI:
                                 "application/json": MediaType(
                                     media_type_schema=PydanticSchema(
                                         schema_class=PongResponse
+                                    )
+                                )
+                            },
+                        )
+                    },
+                )
+            )
+        },
+    )
+
+
+def construct_base_open_api_4_generic_response(response_schema: type) -> OpenAPI:
+    return OpenAPI(
+        info=Info(
+            title="My own API",
+            version="v0.0.1",
+        ),
+        paths={
+            "/ping": PathItem(
+                post=Operation(
+                    requestBody=RequestBody(
+                        content={
+                            "application/json": MediaType(
+                                media_type_schema=PydanticSchema(
+                                    schema_class=PingRequest
+                                )
+                            )
+                        }
+                    ),
+                    responses={
+                        "200": Response(
+                            description="pong",
+                            content={
+                                "application/json": MediaType(
+                                    media_type_schema=PydanticSchema(
+                                        schema_class=response_schema
                                     )
                                 )
                             },


### PR DESCRIPTION
used the regex from pydantic.json_schema.GenerateJSONSchema.normalize_name to replace all characters that are invalid reference names.