### PR TITLE
Fix naming for nested classes

### DIFF
--- a/openapi_pydantic/util.py
+++ b/openapi_pydantic/util.py
@@ -78,8 +78,7 @@ def construct_open_api_with_schema_class(
     if not schema_classes:
         return open_api
 
-    schema_classes.sort(key=lambda x: x.__name__)
-    logger.debug("schema_classes: %s", schema_classes)
+    schema_classes.sort(key=lambda x: x.__qualname__)
 
     # update new_open_api with new #/components/schemas
     if PYDANTIC_V2:
@@ -174,11 +173,19 @@ def _construct_ref_obj(pydantic_schema: PydanticSchema[PydanticType]) -> Referen
     for JSONschema $ref names will get replaced with underscores.
     Especially needed for Pydantic generic Models with brackets "[]"
 
+    For nested classes where the qualified name is not the same as the name of the
+    class, we need to prepend the module name in front of the qualified name. Otherwise,
+    just use the regular name of the class.
+
     see: https://github.com/pydantic/pydantic/blob/aee6057378ccfec02126bf9c984a9b6d6b411777/pydantic/json_schema.py#L2031
     """
-    ref_name = re.sub(
-        r"[^a-zA-Z0-9.\-_]", "_", pydantic_schema.schema_class.__name__
-    ).replace(".", "__")
+    module = pydantic_schema.schema_class.__module__
+    name = pydantic_schema.schema_class.__name__
+    qual_name = pydantic_schema.schema_class.__qualname__
+    specify_qualified_name = qual_name != name
+    schema_name = f"{module}.{qual_name}" if specify_qualified_name else name
+
+    ref_name = re.sub(r"[^a-zA-Z0-9.\-_]", "_", schema_name).replace(".", "__")
     ref_obj = Reference(**{"$ref": ref_prefix + ref_name})
     logger.debug(f"ref_obj={ref_obj}")
     return ref_obj


### PR DESCRIPTION
fixes https://github.com/mike-oakley/openapi-pydantic/issues/67

See the docstrings, for nested classes we need to use [__qualname__](https://docs.python.org/3/library/stdtypes.html#definition.__qualname__) instead of __name__. We also need to prepend the module name, because that's what pydantic does as well.

I also updated the sorting to use `__qualname__` instead of `__name__`.

Can be tested with:
```python
from openapi_pydantic import OpenAPI
from openapi_pydantic.util import PydanticSchema, construct_open_api_with_schema_class
from pydantic import BaseModel, Field


def construct_base_open_api() -> OpenAPI:
    return OpenAPI.model_validate(
        {
            "info": {"title": "My own API", "version": "v0.0.1"},
            "paths": {
                "/a": {
                    "post": {
                        "requestBody": {
                            "content": {
                                "application/json": {
                                    "schema": PydanticSchema(schema_class=ResourceA.Body)
                                }
                            }
                        },
                    }
                },
                "/b": {
                    "post": {
                        "requestBody": {
                            "content": {
                                "application/json": {
                                    "schema": PydanticSchema(schema_class=ResourceB.Body)
                                }
                            }
                        },
                    }
                },
            },
        }
    )


class ResourceA:
    class Body(BaseModel):
        a: str


class ResourceB:
    class Body(BaseModel):
        b: str


open_api = construct_base_open_api()
open_api = construct_open_api_with_schema_class(open_api)

print(open_api.model_dump_json(by_alias=True, exclude_none=True, indent=2))
```