### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/openapi_pydantic/v3/v3_0/README.md
+++ b/openapi_pydantic/v3/v3_0/README.md
@@ -26,7 +26,7 @@ the following fields are used with [alias](https://pydantic-docs.helpmanual.io/u
 
 ## Non-pydantic schema types
 
-Due to the constriants of python typing structure (not able to handle dynamic field names),
+Due to the constraints of python typing structure (not able to handle dynamic field names),
 the following schema classes are actually just a typing of `Dict`:
 
 | Schema Type | Implementation |

--- a/openapi_pydantic/v3/v3_0/schema.py
+++ b/openapi_pydantic/v3/v3_0/schema.py
@@ -132,7 +132,7 @@ class Schema(BaseModel):
 
     The title can be used to decorate a user interface with
     information about the data produced by this user interface.
-    The title will preferrably be short.
+    The title will preferably be short.
     """
 
     multipleOf: Optional[float] = Field(default=None, gt=0.0)

--- a/openapi_pydantic/v3/v3_1/README.md
+++ b/openapi_pydantic/v3/v3_1/README.md
@@ -28,7 +28,7 @@ the following fields are used with [alias](https://pydantic-docs.helpmanual.io/u
 
 ## Non-pydantic schema types
 
-Due to the constriants of python typing structure (not able to handle dynamic field names),
+Due to the constraints of python typing structure (not able to handle dynamic field names),
 the following schema classes are actually just a typing of `Dict`:
 
 | Schema Type | Implementation |

--- a/tests/data/swagger_openapi_v3.0.1.json
+++ b/tests/data/swagger_openapi_v3.0.1.json
@@ -207,7 +207,7 @@
           "pet"
         ],
         "summary": "Finds Pets by tags",
-        "description": "Muliple tags can be provided with comma separated strings. Use         tag1, tag2, tag3 for testing.",
+        "description": "Multiple tags can be provided with comma separated strings. Use         tag1, tag2, tag3 for testing.",
         "operationId": "findPetsByTags",
         "parameters": [
           {


### PR DESCRIPTION
% `codespell ` # https://pypi.org/project/codespell
```
./tests/data/swagger_openapi_v3.0.1.json:210: Muliple ==> Multiple
./openapi_pydantic/v3/v3_0/README.md:29: constriants ==> constraints
./openapi_pydantic/v3/v3_0/schema.py:135: preferrably ==> preferably
./openapi_pydantic/v3/v3_1/README.md:31: constriants ==> constraints
```
% `codespell --write-changes`
